### PR TITLE
refactor setting scenario colours

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '320288'
+ValidationKey: '341054'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -6,3 +6,4 @@ AcceptedWarnings:
 AcceptedNotes: All declared Imports should be used.
 allowLinterWarnings: yes
 enforceVersionUpdate: no
+skipCoverage: no

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -63,6 +63,6 @@ jobs:
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: bae853d82da476eee0e0a57960ee6b741a3b3fb7  # frozen: v0.4.3
+    rev: 3b70240796cdccbe1474b0176560281aaded97e6  # frozen: v0.4.3.9003
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamPlotComparison: Create comparison plots for your model results'
-version: 0.0.16
-date-released: '2024-10-22'
+version: 0.0.17
+date-released: '2024-12-05'
 abstract: A frameworks to create comparison plots for your model results.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamPlotComparison
 Title: Create comparison plots for your model results
-Version: 0.0.16
-Date: 2024-10-22
+Version: 0.0.17
+Date: 2024-12-05
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Christof", "Schoetz", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Create comparison plots for your model results
 
-R package **piamPlotComparison**, version **0.0.16**
+R package **piamPlotComparison**, version **0.0.17**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/piamPlotComparison)](https://cran.r-project.org/package=piamPlotComparison)  [![R build status](https://github.com/pik-piam/piamPlotComparison/workflows/check/badge.svg)](https://github.com/pik-piam/piamPlotComparison/actions) [![codecov](https://codecov.io/gh/pik-piam/piamPlotComparison/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamPlotComparison) [![r-universe](https://pik-piam.r-universe.dev/badges/piamPlotComparison)](https://pik-piam.r-universe.dev/builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/piamPlotComparison)](https://cran.r-project.org/package=piamPlotComparison) [![R build status](https://github.com/pik-piam/piamPlotComparison/workflows/check/badge.svg)](https://github.com/pik-piam/piamPlotComparison/actions) [![codecov](https://codecov.io/gh/pik-piam/piamPlotComparison/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamPlotComparison) [![r-universe](https://pik-piam.r-universe.dev/badges/piamPlotComparison)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamPlotComparison** in publications use:
 
-Benke F, Schoetz C (2024). _piamPlotComparison: Create comparison plots for your model results_. R package version 0.0.16, <https://github.com/pik-piam/piamPlotComparison>.
+Benke F, Schoetz C (2024). _piamPlotComparison: Create comparison plots for your model results_. R package version 0.0.17, <https://github.com/pik-piam/piamPlotComparison>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {piamPlotComparison: Create comparison plots for your model results},
   author = {Falk Benke and Christof Schoetz},
   year = {2024},
-  note = {R package version 0.0.16},
+  note = {R package version 0.0.17},
   url = {https://github.com/pik-piam/piamPlotComparison},
 }
 ```

--- a/inst/compareScenarios/cs_main.Rmd
+++ b/inst/compareScenarios/cs_main.Rmd
@@ -172,7 +172,18 @@ dataScen <-
 ```{r define scenario colors}
 # Get colors of scenarios to be used, e.g., in the info sections.
 # They will coincide with the colors of the scenarios in line plots.
-scenarioColors <- plotstyle(fileReference$newScenarioName)
+
+goodColors <- c(
+  "#e6194B", "#3cb44b", "#4363d8",
+  "#f58231", "#911eb4", "#469990", "#9A6324",
+  "#800000", "#808000", "#000075", "#f032e6",
+  "#ffd610", "#404040", "#42d4f4", "#bfef45",
+  "#B0B0B0", "#dcbeff", "#aaffc3", "#fabed4"
+)
+
+scenarioColors <- goodColors[seq_along(fileReference$newScenarioName)]
+names(scenarioColors) <- fileReference$newScenarioName
+
 lightenColor <- function(clr, by) {
   colRGB <- colorRamp(c(clr, "white"))(by)
   rgb(colRGB[1], colRGB[2], colRGB[3], maxColorValue = 255)
@@ -284,7 +295,7 @@ data <- as.quitte(data)
 
 varNames <- c(
   "availableSections", "dataScenNested", "env", "envToolsRstudio",
-  "fn", "insertExprAtStartOfFun", "lightenColor", "loadCfg", "matches", 
+  "fn", "insertExprAtStartOfFun", "lightenColor", "loadCfg", "matches",
   "oldRsSetNotebookGraphicsOption")
 for (vn in varNames) if (exists(vn)) rm(list = vn)
 rm(varNames)


### PR DESCRIPTION
When setting scenario colours, rather choose from a predefined set of colours than relying on mip::plotstyle(), because
- plotstyle introduces unforeseeable side effects (see https://github.com/pik-piam/mip/issues/114)
- we do not maintain colours for our scenarios in plotstlye anyways, so we always get the default colours (which will now be defined explicitly im piamPlotComparison)