### PR TITLE
adjust parameter in rmarkdown::render

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '220836'
+ValidationKey: '241716'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '241716'
+ValidationKey: '241740'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -44,6 +44,13 @@ jobs:
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
           [ -f requirements.txt ] && pip install -r requirements.txt || true
 
+      - name: Run pre-commit checks
+        shell: bash
+        run: |
+          python -m pip install pre-commit
+          python -m pip freeze --local
+          pre-commit run --show-diff-on-failure --color=always --all-files
+
       - name: Verify validation key
         shell: Rscript {0}
         run: lucode2:::validkey(stopIfInvalid = TRUE)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
     -   id: readme-rmd-rendered
     -   id: use-tidy-description
 ci:
-    autoupdate_schedule: quarterly
+    autoupdate_schedule: weekly

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'piamPlotComparison: Create comparison plots for your model results'
 version: 0.1.2
-date-released: '2025-02-24'
+date-released: '2025-02-26'
 abstract: A frameworks to create comparison plots for your model results.
 authors:
 - family-names: Benke

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamPlotComparison: Create comparison plots for your model results'
-version: 0.1.1
-date-released: '2024-12-19'
+version: 0.1.2
+date-released: '2025-02-24'
 abstract: A frameworks to create comparison plots for your model results.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: piamPlotComparison
 Title: Create comparison plots for your model results
 Version: 0.1.2
-Date: 2025-02-24
+Date: 2025-02-26
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Christof", "Schoetz", role = "aut")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamPlotComparison
 Title: Create comparison plots for your model results
-Version: 0.1.1
-Date: 2024-12-19
+Version: 0.1.2
+Date: 2025-02-24
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Christof", "Schoetz", role = "aut")

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -150,9 +150,9 @@ compareScenarios <- function(
 
   outputFormat <- tolower(outputFormat)[[1]]
   if (outputFormat == "pdf") {
-    outputFormat <- "pdf_document"
+    outputFormatRmarkdown <- "pdf_document"
   } else if (outputFormat == "html") {
-    outputFormat <- "html_document"
+    outputFormatRmarkdown <- "html_document"
   } else if (outputFormat == "rmd") {
     return(.compareScenarios2Rmd(projectLibrary, yamlParams, outputDir, outputFile))
   }
@@ -168,23 +168,27 @@ compareScenarios <- function(
               outputDir, recursive = TRUE)
   }
 
-  outputDir <- file.path(outputDir, "compareScenarios")
-
   # avoid potential problems with write permissions on the copied files
   Sys.chmod(list.files(outputDir, full.names = TRUE))
 
+  # there are issues with tinytex that currently cause a crash when setting
+  # output_dir directly.
+
   rmarkdown::render(
     templateInOutputDir,
-    intermediates_dir = outputDir,
-    output_dir = outputDir,
+    # output_dir = outputDir,
     output_file = outputFile,
-    output_format = outputFormat,
+    output_format = outputFormatRmarkdown,
     params = yamlParams,
     envir = envir,
     quiet = quiet
   )
 
-  unlink(outputDir, recursive = TRUE)
+  # manually copy generated file to outputDir until tinytex is fixed
+  file.copy(file.path(outputDir, "compareScenarios", paste0(outputFile, ".", outputFormat)),
+            outputDir, recursive = TRUE)
+
+  unlink(file.path(outputDir, "compareScenarios"), recursive = TRUE)
 }
 
 # Copies the CompareScenarios-Rmds to the specified location and modifies

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -168,6 +168,8 @@ compareScenarios <- function(
               outputDir, recursive = TRUE)
   }
 
+  outputDir <- file.path(outputDir, "compareScenarios")
+
   # avoid potential problems with write permissions on the copied files
   Sys.chmod(list.files(outputDir, full.names = TRUE))
 
@@ -182,7 +184,7 @@ compareScenarios <- function(
     quiet = quiet
   )
 
-  unlink(file.path(outputDir, "compareScenarios"), recursive = TRUE)
+  unlink(outputDir, recursive = TRUE)
 }
 
 # Copies the CompareScenarios-Rmds to the specified location and modifies

--- a/R/compareScenarios.R
+++ b/R/compareScenarios.R
@@ -172,7 +172,7 @@ compareScenarios <- function(
   Sys.chmod(list.files(outputDir, full.names = TRUE))
 
   # there are issues with tinytex that currently cause a crash when setting
-  # output_dir directly.
+  # output_dir directly. see https://github.com/rstudio/rmarkdown/issues/2589
 
   rmarkdown::render(
     templateInOutputDir,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Create comparison plots for your model results
 
-R package **piamPlotComparison**, version **0.1.1**
+R package **piamPlotComparison**, version **0.1.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamPlotComparison)](https://cran.r-project.org/package=piamPlotComparison) [![R build status](https://github.com/pik-piam/piamPlotComparison/workflows/check/badge.svg)](https://github.com/pik-piam/piamPlotComparison/actions) [![codecov](https://codecov.io/gh/pik-piam/piamPlotComparison/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamPlotComparison) [![r-universe](https://pik-piam.r-universe.dev/badges/piamPlotComparison)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamPlotComparison** in publications use:
 
-Benke F, Schoetz C (2024). "piamPlotComparison: Create comparison plots for your model results." Version: 0.1.1, <https://github.com/pik-piam/piamPlotComparison>.
+Benke F, Schoetz C (2025). "piamPlotComparison: Create comparison plots for your model results." Version: 0.1.2, <https://github.com/pik-piam/piamPlotComparison>.
 
 A BibTeX entry for LaTeX users is
 
@@ -54,9 +54,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamPlotComparison: Create comparison plots for your model results},
   author = {Falk Benke and Christof Schoetz},
-  date = {2024-12-19},
-  year = {2024},
+  date = {2025-02-24},
+  year = {2025},
   url = {https://github.com/pik-piam/piamPlotComparison},
-  note = {Version: 0.1.1},
+  note = {Version: 0.1.2},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamPlotComparison: Create comparison plots for your model results},
   author = {Falk Benke and Christof Schoetz},
-  date = {2025-02-24},
+  date = {2025-02-26},
   year = {2025},
   url = {https://github.com/pik-piam/piamPlotComparison},
   note = {Version: 0.1.2},


### PR DESCRIPTION
tinytex / rmarkdown currently are broken
https://github.com/rstudio/rmarkdown/issues/2589

this fix avoids the problematic parameter `output_dir`

should only occur under tinytex 0.55.2
