### PR TITLE
introduce new macro pandocbounded to custom template

### DIFF
--- a/inst/compareScenarios/cs_latex_template.tex
+++ b/inst/compareScenarios/cs_latex_template.tex
@@ -267,15 +267,17 @@ $endif$
 $if(graphics)$
 \usepackage{graphicx}
 \makeatletter
-\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
-\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
-\makeatother
-% Scale images if necessary, so that they will not overflow the page
-% margins by default, and it is still possible to overwrite the defaults
-% using explicit options in \includegraphics[width, height, ...]{}
-\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+\newsavebox\pandoc@box
+\newcommand*\pandocbounded[1]{% scales image to fit in text height/width
+  \sbox\pandoc@box{#1}%
+  \Gscale@div\@tempa{\textheight}{\dimexpr\ht\pandoc@box+\dp\pandoc@box\relax}%
+  \Gscale@div\@tempb{\linewidth}{\wd\pandoc@box}%
+  \ifdim\@tempb\p@<\@tempa\p@\let\@tempa\@tempb\fi% select the smaller of both
+  \ifdim\@tempa\p@<\p@\scalebox{\@tempa}{\usebox\pandoc@box}%
+  \else\usebox{\pandoc@box}%
+  \fi%
+}
 % Set default figure placement to htbp
-\makeatletter
 \def\fps@figure{htbp}
 \makeatother
 $endif$


### PR DESCRIPTION
Pandoc 3.2.1 introduced new LaTex macro \pandocbounded.
If custom templates are used with the new LaTeX writer, they will have to be updated to include the new \pandocbounded macro, or an error will be raised because of the undefined macro.

See:  https://github.com/Wandmalfarbe/pandoc-latex-template/issues/391

Copied over code: https://github.com/jgm/pandoc/blob/7b29962d869224e19e677cf5acc3aa3eaec1d352/data/templates/common.latex#L97-L113

