### PR TITLE
disable custom latex template

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '285838'
+ValidationKey: '307230'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamPlotComparison: Create comparison plots for your model results'
-version: 0.1.4
-date-released: '2025-11-25'
+version: 0.1.5
+date-released: '2026-01-29'
 abstract: A frameworks to create comparison plots for your model results.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamPlotComparison
 Title: Create comparison plots for your model results
-Version: 0.1.4
-Date: 2025-11-25
+Version: 0.1.5
+Date: 2026-01-29
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Christof", "Schoetz", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Create comparison plots for your model results
 
-R package **piamPlotComparison**, version **0.1.4**
+R package **piamPlotComparison**, version **0.1.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamPlotComparison)](https://cran.r-project.org/package=piamPlotComparison) [![R build status](https://github.com/pik-piam/piamPlotComparison/workflows/check/badge.svg)](https://github.com/pik-piam/piamPlotComparison/actions) [![codecov](https://codecov.io/gh/pik-piam/piamPlotComparison/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamPlotComparison) [![r-universe](https://pik-piam.r-universe.dev/badges/piamPlotComparison)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamPlotComparison** in publications use:
 
-Benke F, Schoetz C (2025). "piamPlotComparison: Create comparison plots for your model results." Version: 0.1.4, <https://github.com/pik-piam/piamPlotComparison>.
+Benke F, Schoetz C (2026). "piamPlotComparison: Create comparison plots for your model results." Version: 0.1.5, <https://github.com/pik-piam/piamPlotComparison>.
 
 A BibTeX entry for LaTeX users is
 
@@ -54,9 +54,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {piamPlotComparison: Create comparison plots for your model results},
   author = {Falk Benke and Christof Schoetz},
-  date = {2025-11-25},
-  year = {2025},
+  date = {2026-01-29},
+  year = {2026},
   url = {https://github.com/pik-piam/piamPlotComparison},
-  note = {Version: 0.1.4},
+  note = {Version: 0.1.5},
 }
 ```

--- a/inst/compareScenarios/cs_main.Rmd
+++ b/inst/compareScenarios/cs_main.Rmd
@@ -7,7 +7,6 @@ output:
     number_sections: yes
     toc_depth: 6
     keep_tex: false
-    template: cs_latex_template.tex
     extra_dependencies: ["float"]
     includes: 
       in_header: cs_pdf_header_include.tex


### PR DESCRIPTION
This PR disables the use of the custom latex template: https://github.com/fbenke-pik/piamPlotComparison/blob/master/inst/compareScenarios/cs_latex_template.tex

It was originally introduced for customizations of the standard template (but it is unclear to me what exactly is changed). The problem with this approach is that the custom template needs to be aligned with the corresponding pandoc version. This one was forked from pandoc2.x and creates problems with pandoc3.x which requires loading packages in a different order. 

We had similar problems [before](https://github.com/pik-piam/piamPlotComparison/pull/22). 

For now, we disable the custom template to check if this creates problems in our current pfds. If so, we can either bring it back or find a different approach to deal with necessary customizations.